### PR TITLE
refactor: clean up import statements in test files for consistency

### DIFF
--- a/.changeset/gentle-falcons-doubt.md
+++ b/.changeset/gentle-falcons-doubt.md
@@ -1,6 +1,0 @@
----
-"@shubhdeep12/resend-cli": patch
----
-
-- cosmetic changes
-- Added upgrade command and version checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shubhdeep12/resend-cli
 
+## 0.4.6
+
+### Patch Changes
+
+- 588739d: - cosmetic changes
+  - Added upgrade command and version checks
+
 ## 0.4.5
 
 ### Patch Changes

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: Use when the user wants to run Resend operations from the command l
 license: MIT
 metadata:
   author: Shubhdeep
-  version: "0.4.5"
+  version: "0.4.6"
   homepage: https://github.com/Shubhdeep12/resend-cli
   source: https://github.com/Shubhdeep12/resend-cli
 inputs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shubhdeep12/resend-cli",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "description": "CLI for Resend",
   "license": "MIT",

--- a/tests/commands/api-keys.spec.ts
+++ b/tests/commands/api-keys.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runAppWithOutput } from "../test-utils/helpers.js";
 import { mockSuccessResponse } from "../test-utils/mock-fetch.js";
 import { apiKeys as apiKeySnapshots } from "../test-utils/snapshots.js";

--- a/tests/commands/auth.spec.ts
+++ b/tests/commands/auth.spec.ts
@@ -8,7 +8,11 @@ import {
   vi,
 } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runApp } from "../test-utils/helpers.js";
 
 describe("auth commands", () => {

--- a/tests/commands/broadcasts.spec.ts
+++ b/tests/commands/broadcasts.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runAppWithOutput } from "../test-utils/helpers.js";
 import { mockSuccessResponse } from "../test-utils/mock-fetch.js";
 import { broadcasts as broadcastSnapshots } from "../test-utils/snapshots.js";

--- a/tests/commands/contact-properties.spec.ts
+++ b/tests/commands/contact-properties.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runAppWithOutput } from "../test-utils/helpers.js";
 import { mockSuccessResponse } from "../test-utils/mock-fetch.js";
 import { contactProperties as contactPropertySnapshots } from "../test-utils/snapshots.js";

--- a/tests/commands/contacts.spec.ts
+++ b/tests/commands/contacts.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runApp, runAppWithOutput } from "../test-utils/helpers.js";
 import { mockSuccessResponse } from "../test-utils/mock-fetch.js";
 import { contacts as contactSnapshots } from "../test-utils/snapshots.js";

--- a/tests/commands/domains.spec.ts
+++ b/tests/commands/domains.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runAppWithOutput, runAppWithStdout } from "../test-utils/helpers.js";
 import {
   mockErrorResponse,

--- a/tests/commands/emails.spec.ts
+++ b/tests/commands/emails.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import {
   runApp,
   runAppWithOutput,

--- a/tests/commands/segments.spec.ts
+++ b/tests/commands/segments.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runAppWithOutput } from "../test-utils/helpers.js";
 import { mockSuccessResponse } from "../test-utils/mock-fetch.js";
 import { segments as segmentSnapshots } from "../test-utils/snapshots.js";

--- a/tests/commands/templates.spec.ts
+++ b/tests/commands/templates.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runAppWithOutput } from "../test-utils/helpers.js";
 import { mockSuccessResponse } from "../test-utils/mock-fetch.js";
 import { templates as templateSnapshots } from "../test-utils/snapshots.js";

--- a/tests/commands/topics.spec.ts
+++ b/tests/commands/topics.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runAppWithOutput } from "../test-utils/helpers.js";
 import { mockSuccessResponse } from "../test-utils/mock-fetch.js";
 import { topics as topicSnapshots } from "../test-utils/snapshots.js";

--- a/tests/commands/webhooks.spec.ts
+++ b/tests/commands/webhooks.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "#/app.js";
-import { disableFetchMocks, enableFetchMocks, resetConfigMock } from "../test-utils/cli-mocks.js";
+import {
+  disableFetchMocks,
+  enableFetchMocks,
+  resetConfigMock,
+} from "../test-utils/cli-mocks.js";
 import { runAppWithOutput } from "../test-utils/helpers.js";
 import { mockSuccessResponse } from "../test-utils/mock-fetch.js";
 import { webhooks as webhookSnapshots } from "../test-utils/snapshots.js";

--- a/tests/test-utils/enable-fetch-mock.ts
+++ b/tests/test-utils/enable-fetch-mock.ts
@@ -6,9 +6,7 @@
 import { vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
 
-const fetchMock = createFetchMock(
-  vi as Parameters<typeof createFetchMock>[0],
-);
+const fetchMock = createFetchMock(vi as Parameters<typeof createFetchMock>[0]);
 fetchMock.enableMocks();
 
 /** Re-enable the fetch mock (e.g. in beforeEach) so it is active in the current context. */


### PR DESCRIPTION
- Updated multiple test files to format import statements for `cli-mocks.js` consistently.
- Improved readability and maintainability of test code by standardizing import styles.

## Description

<!-- What does this PR do? -->

## PR guidelines

CI will run the following. Please ensure they pass locally before requesting review:

- [ ] **Lint** — `pnpm lint`
- [ ] **Typecheck** — `pnpm typecheck`
- [ ] **Tests** — `pnpm test`
- [ ] **Coverage** — `pnpm test:coverage` (must meet thresholds)
- [ ] **Changeset** — `pnpm changeset` (for user-facing changes only)

If you added or changed a command, run `pnpm docs:generate` and commit the updated `docs/COMMANDS.md`.
